### PR TITLE
🐋 Clean Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,6 @@ ENV PYTHONIOENCODING=utf-8
 ENV QT_QPA_PLATFORM=offscreen
 ENV TZ=US/Pacific
 
-# Instala paquetes en el sistema operativo
-RUN apt update && apt full-upgrade --yes && apt install --yes \
-    curl \
-    exa \
-    git \
-    neofetch \
-    neovim \
-    pip \
-    ripgrep \
-    tmux
-
 # Use Python 3 as the default version of Python
 RUN ln --symbolic /usr/bin/python3 /usr/bin/python
 
@@ -29,15 +18,7 @@ RUN pip install \
     black \
     flake8 \
     ipython \
-    powerline-shell \
     pylint \
     pyright \
     pytest \
     rope
-
-# Importa archivos de configuración
-RUN mkdir --parents ${HOME}/repos && \
-    git clone --bare https://github.com/devarops/dotfiles.git ${HOME}/repos/dotfiles.git && \
-    git --git-dir=${HOME}/repos/dotfiles.git --work-tree=${HOME} checkout && \
-    git --git-dir=${HOME}/repos/dotfiles.git --work-tree=${HOME} config --local status.showUntrackedFiles no
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV PYTHONIOENCODING=utf-8
 ENV QT_QPA_PLATFORM=offscreen
 ENV TZ=US/Pacific
 
+# Instala paquetes en el sistema operativo
+RUN apt update && apt full-upgrade --yes && apt install --yes \
+    pip
+
 # Use Python 3 as the default version of Python
 RUN ln --symbolic /usr/bin/python3 /usr/bin/python
 

--- a/tests/test_referee_dataset_simple.py
+++ b/tests/test_referee_dataset_simple.py
@@ -1,5 +1,5 @@
 from ..ctf import get_submission_list, load_submission, Referee
-from .utils_tests import _test_length_from_dataset, _test_get_path
+from .utils_tests import _remove_if_exists, _test_length_from_dataset, _test_get_path
 import os
 import pandas as pd
 import pytest
@@ -104,51 +104,48 @@ def test_get_example_submission_path():
 
 def test_save_training_dataset():
     path_to_training = referee.get_training_path()
-    if os.path.exists(path_to_training):
-        os.remove(path_to_training)
+    _remove_if_exists(path_to_training)
     referee.save_training_dataset()
     assert os.path.exists(path_to_training)
     obtained_first_column = pd.read_csv(path_to_training).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
-    os.remove(path_to_training)
+    _remove_if_exists(path_to_training)
 
 
 def test_save_testing_dataset():
     path_to_testing = referee.get_testing_path()
-    if os.path.exists(path_to_testing):
-        os.remove(path_to_testing)
+    _remove_if_exists(path_to_testing)
     referee.save_testing_dataset()
     assert os.path.exists(path_to_testing)
     obtained_first_column = pd.read_csv(path_to_testing).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
-    os.remove(path_to_testing)
+    _remove_if_exists(path_to_testing)
 
 
 def test_save_example_submission():
     path_to_example_submission = referee.get_example_submission_path()
-    if os.path.exists(path_to_example_submission):
-        os.remove(path_to_example_submission)
+    _remove_if_exists(path_to_example_submission)
     referee.save_example_submission()
     assert os.path.exists(path_to_example_submission)
     obtained_first_column = pd.read_csv(path_to_example_submission).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
-    os.remove(path_to_example_submission)
+    _remove_if_exists(path_to_example_submission)
 
 
 def test_init():
     referee.init()
     path_to_training = referee.get_training_path()
     assert os.path.exists(path_to_training)
-    os.remove(path_to_training)
+    _remove_if_exists(path_to_training)
     path_to_testing = referee.get_testing_path()
     assert os.path.exists(path_to_testing)
-    os.remove(path_to_testing)
+    _remove_if_exists(path_to_testing)
     path_to_example_submission = referee.get_example_submission_path()
     assert os.path.exists(path_to_example_submission)
-    os.remove(path_to_example_submission)
+    _remove_if_exists(path_to_example_submission)
 
 
 def test_load_submission():

--- a/tests/test_referee_dataset_simple.py
+++ b/tests/test_referee_dataset_simple.py
@@ -1,6 +1,10 @@
 from ..ctf import get_submission_list, load_submission, Referee
-from .utils_tests import _remove_if_exists, _test_length_from_dataset, _test_get_path
-import os
+from .utils_tests import (
+    _assert_file_exits,
+    _remove_if_exists,
+    _test_length_from_dataset,
+    _test_get_path,
+)
 import pandas as pd
 import pytest
 
@@ -106,7 +110,7 @@ def test_save_training_dataset():
     path_to_training = referee.get_training_path()
     _remove_if_exists(path_to_training)
     referee.save_training_dataset()
-    assert os.path.exists(path_to_training)
+    _assert_file_exits(path_to_training)
     obtained_first_column = pd.read_csv(path_to_training).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
@@ -117,7 +121,7 @@ def test_save_testing_dataset():
     path_to_testing = referee.get_testing_path()
     _remove_if_exists(path_to_testing)
     referee.save_testing_dataset()
-    assert os.path.exists(path_to_testing)
+    _assert_file_exits(path_to_testing)
     obtained_first_column = pd.read_csv(path_to_testing).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
@@ -128,7 +132,7 @@ def test_save_example_submission():
     path_to_example_submission = referee.get_example_submission_path()
     _remove_if_exists(path_to_example_submission)
     referee.save_example_submission()
-    assert os.path.exists(path_to_example_submission)
+    _assert_file_exits(path_to_example_submission)
     obtained_first_column = pd.read_csv(path_to_example_submission).columns[0]
     expected_first_column = "id"
     assert expected_first_column == obtained_first_column
@@ -138,13 +142,13 @@ def test_save_example_submission():
 def test_init():
     referee.init()
     path_to_training = referee.get_training_path()
-    assert os.path.exists(path_to_training)
+    _assert_file_exits(path_to_training)
     _remove_if_exists(path_to_training)
     path_to_testing = referee.get_testing_path()
-    assert os.path.exists(path_to_testing)
+    _assert_file_exits(path_to_testing)
     _remove_if_exists(path_to_testing)
     path_to_example_submission = referee.get_example_submission_path()
-    assert os.path.exists(path_to_example_submission)
+    _assert_file_exits(path_to_example_submission)
     _remove_if_exists(path_to_example_submission)
 
 

--- a/tests/test_save_dataset.py
+++ b/tests/test_save_dataset.py
@@ -1,6 +1,7 @@
 from ..ctf import Referee
-import os
 import pandas as pd
+
+from .utils_tests import _remove_if_exists
 
 path_to_submission_directory = "tests/test_dataset_pollos_petrel/"
 path_to_complete_dataset = path_to_submission_directory + "complete_dataset.csv"
@@ -10,8 +11,7 @@ referee = Referee(path_to_complete_dataset)
 
 def test_save_training_dataset_includes_na():
     path_to_training = referee.get_training_path()
-    if os.path.exists(path_to_training):
-        os.remove(path_to_training)
+    _remove_if_exists(path_to_training)
     referee.save_training_dataset()
     obtained_count_na = pd.read_csv(path_to_training).isna().sum().sum()
     expected_count_na = 31

--- a/tests/test_save_dataset.py
+++ b/tests/test_save_dataset.py
@@ -16,4 +16,4 @@ def test_save_training_dataset_includes_na():
     obtained_count_na = pd.read_csv(path_to_training).isna().sum().sum()
     expected_count_na = 31
     assert expected_count_na == obtained_count_na
-    os.remove(path_to_training)
+    _remove_if_exists(path_to_training)

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -21,3 +21,7 @@ def _test_get_path(obtained_path, expected_path):
 def _remove_if_exists(path):
     if os.path.exists(path):
         os.remove(path)
+
+
+def _assert_file_exits(path):
+    assert os.path.exists(path)

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,5 +1,6 @@
 import os
 
+
 def _test_length_from_dataset(expected_length, dataset, referee):
     assert_length_dataset(expected_length, dataset, referee)
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,3 +1,5 @@
+import os
+
 def _test_length_from_dataset(expected_length, dataset, referee):
     assert_length_dataset(expected_length, dataset, referee)
 
@@ -13,3 +15,8 @@ def assert_length_dataset(expected_length, dataset, referee):
 
 def _test_get_path(obtained_path, expected_path):
     assert expected_path == obtained_path
+
+
+def _remove_if_exists(path):
+    if os.path.exists(path):
+        os.remove(path)


### PR DESCRIPTION
Quita dependencias que no pertenecIan al CI

## Antecedentes
Las dependecias que quitamos pertenecían al entorno de desarollo. Habíamos agregado estas dependencias para hacer un experimento y al final nos dimos cuenta de que este no era el mejor lugar.



